### PR TITLE
Removed URL parm in blogCategoryResolveMenuItem

### DIFF
--- a/models/Sitemap.php
+++ b/models/Sitemap.php
@@ -333,7 +333,7 @@ class Sitemap extends Model
                 return;
             }
             foreach ($categories as $category) {
-                $result['items'][] = self::getMenuItem($page, $category, $url, $paramName);
+                $result['items'][] = self::getMenuItem($page, $category, $paramName);
             }
         }
 


### PR DESCRIPTION
blogCategoryResolveMenuItem() when used with type 'all-blog-categories' calls self::getMenuItem, which accepts only $page, $menuItem and $paramName parameters.